### PR TITLE
Type for in the 'additionalSpaces' setting is incorrect in the README

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,7 +20,7 @@ On Mac:
 |:--------------------------------- |:----------------------------------------------------|:-------:|:--------:|
 | formate.enable                    | Enables/disables the extension                      | boolean | true     |
 | formate.verticalAlignProperties   | Controls if properties should be aligned vertically | boolean | true     |
-| formate.additionalSpaces          | If vertical alignment is on, this setting is to add extra spaces | boolean | 0     |
+| formate.additionalSpaces          | If vertical alignment is on, this setting is to add extra spaces | number | 0     |
 | formate.alignColon                | Whether colon should be vertical aligned or not | boolean | true    |
 
 


### PR DESCRIPTION
The type for in the 'additionalSpaces' setting is incorrect in the README.md

The third (type) column in the readme says boolean when the type is actually a number in the extension manifest
https://github.com/mblander/formate/blob/09971c64425829d6d4fdd79da789a66cd86387de/README.md#L23
https://github.com/mblander/formate/blob/09971c64425829d6d4fdd79da789a66cd86387de/package.json#L72-L77